### PR TITLE
fix(md-3762): android fix null representation type

### DIFF
--- a/android/src/main/java/com/qliktrialreactnativestraighttable/Representation.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/Representation.java
@@ -19,6 +19,9 @@ public class Representation {
 
   Representation(ReadableMap data) {
     type = data.getString("type");
+    if(type == null) {
+      type = "text";
+    }
     imageUrl = data.getString("imageUrl");
     imageSize = data.getString("imageSize");
     imagePosition = data.getString("imagePosition");


### PR DESCRIPTION
Issue: representation can be null.
Fix: when it's null treat the type as 'text'