### PR TITLE
fix(md-3763): view data crash android

### DIFF
--- a/android/src/main/java/com/qliktrialreactnativestraighttable/DataProvider.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/DataProvider.java
@@ -70,7 +70,7 @@ public class DataProvider extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
   public void setTotals(ReadableArray totals, String totalsLabel, String totalsPosition) {
     this.totalsCells = HeaderViewFactory.getTotalsCellList(totals);
     this.totalsLabel = totalsLabel;
-    this.totalsPosition = totalsPosition;
+    this.totalsPosition = totalsPosition == null ? "noTotals" : totalsPosition;
   }
 
   public void setFirstColumnFrozen(boolean firstColumnFrozen) {


### PR DESCRIPTION
View data table was crashing as no totals position was set.