### PR TITLE
fix(md-3816): links not working cause reordered columns android

### DIFF
--- a/android/src/main/java/com/qliktrialreactnativestraighttable/ClickableTextView.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/ClickableTextView.java
@@ -137,11 +137,6 @@ public class ClickableTextView extends androidx.appcompat.widget.AppCompatTextVi
     }
     String urlText = cell.qText;
     int attrIndex = column.stylingInfo.indexOf("url");
-    if(cell.qAttrExps == null) {
-      this.linkUrl = "error";
-      this.linkLabel = "Error";
-      return;
-    }
     if(attrIndex != -1) {
       HashMap<String, String> value = (HashMap<String, String>) cell.qAttrExps.get(attrIndex);
       urlText = value.get("qText");

--- a/android/src/main/java/com/qliktrialreactnativestraighttable/ClickableTextView.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/ClickableTextView.java
@@ -137,6 +137,11 @@ public class ClickableTextView extends androidx.appcompat.widget.AppCompatTextVi
     }
     String urlText = cell.qText;
     int attrIndex = column.stylingInfo.indexOf("url");
+    if(cell.qAttrExps == null) {
+      this.linkUrl = "error";
+      this.linkLabel = "Error";
+      return;
+    }
     if(attrIndex != -1) {
       HashMap<String, String> value = (HashMap<String, String>) cell.qAttrExps.get(attrIndex);
       urlText = value.get("qText");

--- a/android/src/main/java/com/qliktrialreactnativestraighttable/DataCell.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/DataCell.java
@@ -17,12 +17,13 @@ import java.util.List;
 public class DataCell {
   String type;
   String qText;
-  Double  qNum;
-  int  qElemNumber;
+  Double qNum;
+  int qElemNumber;
   String  qState;
   String imageUrl;
-  int  rowIdx;
-  int  colIdx;
+  int rowIdx;
+  int colIdx;
+  int columnIndex;
   boolean  isDim = false;
   int rawRowIdx;
   int  rawColIdx;
@@ -41,6 +42,7 @@ public class DataCell {
     qState =  source.getString("qState");
     rowIdx =  source.getInt("rowIdx");
     colIdx =  source.getInt("colIdx");
+    columnIndex = column.columnIndex;
     rawRowIdx =  source.getInt("rawRowIdx");
     rawColIdx =  source.getInt("rawColIdx");
     ReadableType qNumType = source.getType("qNum");

--- a/android/src/main/java/com/qliktrialreactnativestraighttable/DataRow.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/DataRow.java
@@ -19,8 +19,8 @@ public class DataRow {
       String key = iterator.nextKey();
       if(!key.equalsIgnoreCase("key")) {
         ReadableMap cellItem = source.getMap(key);
-        int colIdx = cellItem.getInt("colIdx");
-        cells.add(new DataCell(cellItem, columns.get(colIdx)));
+        int rawColIdx = cellItem.getInt("rawColIdx");
+        cells.add(new DataCell(cellItem, columns.get(rawColIdx)));
       }
     }
     Collections.sort(cells, (a, b) -> a.rawColIdx - b.rawColIdx);

--- a/android/src/main/java/com/qliktrialreactnativestraighttable/RowViewHolder.java
+++ b/android/src/main/java/com/qliktrialreactnativestraighttable/RowViewHolder.java
@@ -38,7 +38,7 @@ public class RowViewHolder extends RecyclerView.ViewHolder  {
   public void setData(DataRow dataRow, int rowHeight) {
     for(int i = 0; i < numColumns; i++) {
       DataCell cell = dataRow.cells.get(i);
-      int columnIndex = cell.colIdx;
+      int columnIndex = cell.rawColIdx;
       DataColumn column = dataProvider.dataColumns.get(columnIndex);
 
       if(column.representation.type.equals("image")) {


### PR DESCRIPTION
Fixes column ordering on tables with reordered columns by using rawColIdx instead of colIdx